### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,10 +225,10 @@ functional.**
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=RBN-Apps%2FQuick-Tile-Settings&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#RBN-Apps/Quick-Tile-Settings&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=RBN-Apps/Quick-Tile-Settings&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=RBN-Apps/Quick-Tile-Settings&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/image?repos=RBN-Apps/Quick-Tile-Settings&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=RBN-Apps/Quick-Tile-Settings&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=RBN-Apps/Quick-Tile-Settings&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=RBN-Apps/Quick-Tile-Settings&type=date&legend=top-left" />
  </picture>
 </a>


### PR DESCRIPTION
The star history chart on the project page is currently broken and does not render. This change switches the chart to a working provider so the star history is displayed correctly again, restoring an important indicator for visitors of the repository.